### PR TITLE
CI for the Python wrapper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
-language: cpp
+language:
+- cpp
+- python
+python:
+- 3.6
 compiler:
 - gcc
 dist: trusty
@@ -13,17 +17,23 @@ before_install:
 - git submodule update --init --recursive
 - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
 - sudo apt-get update -qq
+- pyenv global 3.6
 install:
 - sudo apt-get install -qq g++-8
 - sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 90
+- pip3 install sphinx m2r numpy SimpleITK sphinx_rtd_theme PyYAML
 script:
 - mkdir build
 - cd build
-- cmake .. -DDF_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=${CONFIG}
+- cmake .. -DDF_BUILD_TESTS=1 -DCMAKE_BUILD_TYPE=${CONFIG} -DDF_BUILD_PYTHON_WRAPPER=ON -DDF_BUILD_DOCS=ON
 - cmake --build . --config ${CONFIG}
 - ctest --output-on-failure
+- cd ..
+- python3 setup.py install --user
+- python3 -m unittest discover test
 notifications:
   slack:
     secure: yAgy9xahI0+X1uRxzMKejHuFFPHF7jpkB4cCLrmChyMvpR0CLu91Py4mONpfP9HEAvhd2EL9ffapGkJ47sfEkVlPE5EL+yMnAM+xavnbxasMnK99hGfHDGOZt4BW1exbrUnTL99c9urtHkvwOVJ25qXySJUN5boIxfB2kumc2P40sbCOCx3NALLFgaysrHNq/y6Pa9tP1zG06acibb6FCJ+zOY3+1Ad8PhRDwZAWiIZ2y0Ic8TlwCwvDIABVahuuNgeY2Fkrt++SFT+/0o19YRydSpteMgoM6hRhKMe6tholj1bO9JclvFqa1WW1Ik8571WJXICk6d6AGipJafWbH5L410dIi/oyClW45nEpmna2wTQKL3eSIRd5NO4YZlm/yqaqJpXaTMwLGQDJyBurpOVC4DYny47ph8ep8wZ3ORCNiujBsHWWRKYK3MDXZuCVCmuK4wBH+GcCMee1Ww8m5acrY1bHJyEYYmSt4x2r49BXYYA9p9t6Gmwmmk2wJWsiWR1OkkvC1UW/Y6nyFTBu4uD0CPaXXj1in69U0xocdhmeS5txRqsw0HJxmbr+GKSMGmIttTXgZyDKrUsKYqH8KKlAfxPJKJeTuKM6f96v5Zj05FELx90Y8VbZu9auk6QPSIie10c9yCKIdnrzEN15pBhmgVFqJVRWsBy2rGkFmhY=
     on_success: change
     on_failure: always
+


### PR DESCRIPTION
I think it can be useful to have the Python module and the Sphinx docs in the CI system, so we don't forget them when we are working on other components.

Also, we have unit tests in Python, and we can extend them later to easily run fancy tests of the registration algorithm that would be much clumsier using the executable version.