### PR TITLE
No more regularization weight for unary fn

### DIFF
--- a/src/deform_lib/cost_functions/unary_function.h
+++ b/src/deform_lib/cost_functions/unary_function.h
@@ -10,26 +10,13 @@ struct UnaryFunction
         std::unique_ptr<SubFunction> function;
     };
 
-    UnaryFunction(const float regularization_weight = 0.0f)
-        : _regularization_weight(regularization_weight)
-    {
-    }
+    UnaryFunction() {}
+    ~UnaryFunction() {}
 
     void set_fixed_mask(const stk::VolumeFloat& mask)
     {
         _fixed_mask = mask;
     }
-
-    void set_regularization_weight(float weight)
-    {
-        _regularization_weight = weight;
-    }
-#ifdef DF_ENABLE_REGULARIZATION_WEIGHT_MAP
-    void set_regularization_weight_map(stk::VolumeFloat& map)
-    {
-        _regularization_weight_map = map;
-    }
-#endif
 
     void add_function(std::unique_ptr<SubFunction> fn, float weight)
     {
@@ -51,27 +38,17 @@ struct UnaryFunction
             sum += fn.weight * fn.function->cost(p, def);
         }
 
-        float w = _regularization_weight;
-#ifdef DF_ENABLE_REGULARIZATION_WEIGHT_MAP
-        if (_regularization_weight_map.valid())
-            w = _regularization_weight_map(p);
-#endif
-
-        return (1.0f - w) * mask_value * sum;
+        return mask_value * sum;
     }
 
-    void pre_iteration_hook(const int iteration, const stk::VolumeFloat3& def) {
+    void pre_iteration_hook(const int iteration, const stk::VolumeFloat3& def)
+    {
         for (auto& fn : _functions) {
             fn.function->pre_iteration_hook(iteration, def);
         }
     }
 
     stk::VolumeFloat _fixed_mask;
-
-    float _regularization_weight;
-#ifdef DF_ENABLE_REGULARIZATION_WEIGHT_MAP
-    stk::VolumeFloat _regularization_weight_map;
-#endif
 
     std::vector<WeightedFunction> _functions;
 };

--- a/src/deform_lib/registration/gpu/cost_functions/unary_function.h
+++ b/src/deform_lib/registration/gpu/cost_functions/unary_function.h
@@ -12,16 +12,9 @@ public:
         std::unique_ptr<GpuSubFunction> function;
     };
 
-    // TODO: Weights, regularization term, etc
-
-    GpuUnaryFunction() : _regularization_weight(0.0f) {}
-
+    GpuUnaryFunction() {}
     ~GpuUnaryFunction() {}
 
-    void set_regularization_weight(float weight)
-    {
-        _regularization_weight = weight;
-    }
 
     // cost_acc : Cost accumulator for unary term. float2 with E0 and E1.
     void operator()(
@@ -34,11 +27,9 @@ public:
     )
     {
         for (auto& fn : _functions) {
-            fn.function->cost(df, delta, (1.0f-_regularization_weight)*fn.weight,
+            fn.function->cost(df, delta, fn.weight,
                               offset, dims, cost_acc, stream);
         }
-        // TODO: Maybe applying regularization as a separate pass?
-        //       Would make sense for regularization weight maps.
     }
 
     void add_function(std::unique_ptr<GpuSubFunction>& fn, float weight)
@@ -47,8 +38,6 @@ public:
     }
 
 private:
-    float _regularization_weight;
-
     std::vector<WeightedFunction> _functions;
 };
 

--- a/src/deform_lib/registration/gpu_registration_engine.cpp
+++ b/src/deform_lib/registration/gpu_registration_engine.cpp
@@ -56,8 +56,6 @@ void GpuRegistrationEngine::build_unary_function(int level, GpuUnaryFunction& un
 {
     using FunctionPtr = std::unique_ptr<GpuSubFunction>;
 
-    unary_fn.set_regularization_weight(_settings.levels[level].regularization_weight);
-
     for (int i = 0; i < DF_MAX_IMAGE_PAIR_COUNT; ++i) {
         stk::GpuVolume fixed;
         stk::GpuVolume moving;

--- a/src/deform_lib/registration/registration_engine.cpp
+++ b/src/deform_lib/registration/registration_engine.cpp
@@ -395,8 +395,7 @@ void RegistrationEngine::build_unary_function(int level, UnaryFunction& unary_fn
     if (_fixed_mask_pyramid.levels() > 0) {
         unary_fn.set_fixed_mask(_fixed_mask_pyramid.volume(level));
     }
-    unary_fn.set_regularization_weight(_settings.levels[level].regularization_weight);
-
+    
     #ifdef DF_ENABLE_REGULARIZATION_WEIGHT_MAP
         if (_regularization_weight_map.volume(level).valid())
             binary_fn.set_weight_map(_regularization_weight_map.volume(l));


### PR DESCRIPTION
Fixes #52. Don't really know how to introduce this as it will break previous parameters. The sooner the better I guess.