### PR TITLE
Add gamma transform to regulariser

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ block_energy_epsilon: 1e-7
 max_iteration_count: -1
 step_size: 0.5
 regularization_weight: 0.1
+regularization_scale: 1.0
 regularization_exponent: 2.0
 
 levels:
@@ -158,11 +159,12 @@ single `float` value, in that case the same step size will be used in all
 directions, or a sequence `[sx, sy, sz]` of three `float` specifying the size
 for each direction.
 
-`regularization_weight` and `regularization_exponent` control the importance of
-the regularization term. The cost function is specified as `cost = D +
-a*(R^b)`, where `D = Σa_i*C_i` is the data term given by the cost functions
-`C_i` with weights `a_i`, `R` is the regularization term, `a` is the
-regularization weight and `b` the regularization exponent.
+`regularization_weight`, `regularization_scale`, and `regularization_exponent`
+control the importance of the regularization term. The cost function is
+specified as `cost = D + a*((b*R)^c)`, where `D = Σw_i*C_i` is the data term
+given by the cost functions `C_i` with weights `w_i`, `R` is the regularization
+term, `a` is the regularization weight, `b` the regularization scale, and `c`
+the regularization exponent.
 
 `levels`, specifies parameters on a per-level basis. The key indicates which
 level the parameters apply to, where 0 is the bottom of the resolution pyramid

--- a/src/deform_lib/cost_functions/regularizer.h
+++ b/src/deform_lib/cost_functions/regularizer.h
@@ -8,16 +8,27 @@
 
 struct Regularizer
 {
-    Regularizer(float weight=0.0f, float exponent=1.0f, const float3& spacing={1.0f, 1.0f, 1.0f}) :
-        _weight(weight), _half_exponent(0.5f * exponent), _spacing(spacing)
+    Regularizer(
+            const float weight=0.0f,
+            const float scale=1.0f,
+            float exponent=1.0f,
+            const float3& spacing={1.0f, 1.0f, 1.0f})
+        : _weight(weight)
+        , _scale(scale)
+        , _half_exponent(0.5f * exponent)
+        , _spacing(spacing)
     {
     }
 
     virtual ~Regularizer() {}
 
-    void set_regularization_weight(float weight)
+    void set_regularization_weight(const float weight)
     {
         _weight = weight;
+    }
+    void set_regularization_scale(const float scale)
+    {
+        _scale = scale;
     }
     void set_regularization_exponent(const float exponent)
     {
@@ -57,7 +68,7 @@ struct Regularizer
         float3 diff = (def0-_initial(p)) - (def1-_initial(p+step));
 
         float dist_squared = stk::norm2(diff);
-        float step_squared = stk::norm2(step_in_mm);
+        float step_squared = _scale * stk::norm2(step_in_mm);
 
         float w = _weight;
 
@@ -77,6 +88,7 @@ struct Regularizer
     }
 
     float _weight;
+    float _scale;
     float _half_exponent;
     float3 _spacing;
 

--- a/src/deform_lib/registration/gpu/cost_functions/binary_function.cu
+++ b/src/deform_lib/registration/gpu/cost_functions/binary_function.cu
@@ -7,6 +7,7 @@ __global__ void regularizer_kernel(
     cuda::VolumePtr<float4> initial_df,
     float3 delta,
     float weight,
+    float scale,
     float half_exponent,
     int3 offset,
     int3 dims,
@@ -46,15 +47,15 @@ __global__ void regularizer_kernel(
 
             float4 diff_00 = d - dx;
             float dist2_00 = diff_00.x*diff_00.x + diff_00.y*diff_00.y + diff_00.z*diff_00.z;
-            dist2_00 = pow(dist2_00, half_exponent);
+            dist2_00 = pow(scale * dist2_00, half_exponent);
 
             float4 diff_01 = d - (dx+delta4);
             float dist2_01 = diff_01.x*diff_01.x + diff_01.y*diff_01.y + diff_01.z*diff_01.z;
-            dist2_01 = pow(dist2_01, half_exponent);
+            dist2_01 = pow(scale * dist2_01, half_exponent);
 
             float4 diff_10 = (d+delta4) - dx;
             float dist2_10 = diff_10.x*diff_10.x + diff_10.y*diff_10.y + diff_10.z*diff_10.z;
-            dist2_10 = pow(dist2_10, half_exponent);
+            dist2_10 = pow(scale * dist2_10, half_exponent);
 
             o_x.x = dist2_00;
             o_x.y = dist2_01;
@@ -66,15 +67,15 @@ __global__ void regularizer_kernel(
 
             float4 diff_00 = d - dy;
             float dist2_00 = diff_00.x*diff_00.x + diff_00.y*diff_00.y + diff_00.z*diff_00.z;
-            dist2_00 = pow(dist2_00, half_exponent);
+            dist2_00 = pow(scale * dist2_00, half_exponent);
 
             float4 diff_01 = d - (dy+delta4);
             float dist2_01 = diff_01.x*diff_01.x + diff_01.y*diff_01.y + diff_01.z*diff_01.z;
-            dist2_01 = pow(dist2_01, half_exponent);
+            dist2_01 = pow(scale * dist2_01, half_exponent);
 
             float4 diff_10 = (d+delta4) - dy;
             float dist2_10 = diff_10.x*diff_10.x + diff_10.y*diff_10.y + diff_10.z*diff_10.z;
-            dist2_10 = pow(dist2_10, half_exponent);
+            dist2_10 = pow(scale * dist2_10, half_exponent);
 
             o_y.x = dist2_00;
             o_y.y = dist2_01;
@@ -86,15 +87,15 @@ __global__ void regularizer_kernel(
 
             float4 diff_00 = d - dz;
             float dist2_00 = diff_00.x*diff_00.x + diff_00.y*diff_00.y + diff_00.z*diff_00.z;
-            dist2_00 = pow(dist2_00, half_exponent);
+            dist2_00 = pow(scale * dist2_00, half_exponent);
 
             float4 diff_01 = d - (dz+delta4);
             float dist2_01 = diff_01.x*diff_01.x + diff_01.y*diff_01.y + diff_01.z*diff_01.z;
-            dist2_01 = pow(dist2_01, half_exponent);
+            dist2_01 = pow(scale * dist2_01, half_exponent);
 
             float4 diff_10 = (d+delta4) - dz;
             float dist2_10 = diff_10.x*diff_10.x + diff_10.y*diff_10.y + diff_10.z*diff_10.z;
-            dist2_10 = pow(dist2_10, half_exponent);
+            dist2_10 = pow(scale * dist2_10, half_exponent);
 
             o_z.x = dist2_00;
             o_z.y = dist2_01;
@@ -113,11 +114,11 @@ __global__ void regularizer_kernel(
 
         float4 diff_00 = d - dx;
         float dist2_00 = diff_00.x*diff_00.x + diff_00.y*diff_00.y + diff_00.z*diff_00.z;
-        dist2_00 = pow(dist2_00, half_exponent);
+        dist2_00 = pow(scale * dist2_00, half_exponent);
 
         float4 diff_01 = (d+delta4) - dx;
         float dist2_01 = diff_01.x*diff_01.x + diff_01.y*diff_01.y + diff_01.z*diff_01.z;
-        dist2_01 = pow(dist2_01, half_exponent);
+        dist2_01 = pow(scale * dist2_01, half_exponent);
 
         cost_x(gx-1,gy,gz).x = weight*inv_spacing2_exp.x*dist2_00;
         cost_x(gx-1,gy,gz).y = weight*inv_spacing2_exp.x*dist2_01;
@@ -130,11 +131,11 @@ __global__ void regularizer_kernel(
 
         float4 diff_00 = d - dy;
         float dist2_00 = diff_00.x*diff_00.x + diff_00.y*diff_00.y + diff_00.z*diff_00.z;
-        dist2_00 = pow(dist2_00, half_exponent);
+        dist2_00 = pow(scale * dist2_00, half_exponent);
 
         float4 diff_01 = (d+delta4) - dy;
         float dist2_01 = diff_01.x*diff_01.x + diff_01.y*diff_01.y + diff_01.z*diff_01.z;
-        dist2_01 = pow(dist2_01, half_exponent);
+        dist2_01 = pow(scale * dist2_01, half_exponent);
 
         cost_y(gx,gy-1,gz).x = weight*inv_spacing2_exp.y*dist2_00;
         cost_y(gx,gy-1,gz).y = weight*inv_spacing2_exp.y*dist2_01;
@@ -147,11 +148,11 @@ __global__ void regularizer_kernel(
 
         float4 diff_00 = d - dz;
         float dist2_00 = diff_00.x*diff_00.x + diff_00.y*diff_00.y + diff_00.z*diff_00.z;
-        dist2_00 = pow(dist2_00, half_exponent);
+        dist2_00 = pow(scale * dist2_00, half_exponent);
 
         float4 diff_01 = (d+delta4) - dz;
         float dist2_01 = diff_01.x*diff_01.x + diff_01.y*diff_01.y + diff_01.z*diff_01.z;
-        dist2_01 = pow(dist2_01, half_exponent);
+        dist2_01 = pow(scale * dist2_01, half_exponent);
 
         cost_z(gx,gy,gz-1).x = weight*inv_spacing2_exp.z*dist2_00;
         cost_z(gx,gy,gz-1).y = weight*inv_spacing2_exp.z*dist2_01;
@@ -200,6 +201,7 @@ void GpuBinaryFunction::operator()(
             _initial,
             delta,
             _weight,
+            _scale,
             _half_exponent,
             offset,
             dims,

--- a/src/deform_lib/registration/gpu/cost_functions/binary_function.h
+++ b/src/deform_lib/registration/gpu/cost_functions/binary_function.h
@@ -5,14 +5,18 @@
 class GpuBinaryFunction
 {
 public:
-    GpuBinaryFunction() : _weight(0.0f), _half_exponent(1.0f), _spacing{0, 0, 0} {}
+    GpuBinaryFunction() : _weight(0.0f), _scale(1.0f), _half_exponent(1.0f), _spacing{0, 0, 0} {}
     ~GpuBinaryFunction() {}
 
-    void set_regularization_weight(float weight)
+    void set_regularization_weight(const float weight)
     {
         _weight = weight;
     }
-    void set_regularization_exponent(float exponent)
+    void set_regularization_scale(const float scale)
+    {
+        _scale = scale;
+    }
+    void set_regularization_exponent(const float exponent)
     {
         _half_exponent = 0.5f * exponent;
     }
@@ -56,6 +60,7 @@ public:
 
 private:
     float _weight;
+    float _scale;
     float _half_exponent;
     float3 _spacing;
 

--- a/src/deform_lib/registration/gpu_registration_engine.cpp
+++ b/src/deform_lib/registration/gpu_registration_engine.cpp
@@ -138,6 +138,7 @@ void GpuRegistrationEngine::build_binary_function(int level, GpuBinaryFunction& 
 {
     binary_fn.set_fixed_spacing(_fixed_pyramids[0].volume(level).spacing());
     binary_fn.set_regularization_weight(_settings.levels[level].regularization_weight);
+    binary_fn.set_regularization_scale(_settings.levels[level].regularization_scale);
     binary_fn.set_regularization_exponent(_settings.levels[level].regularization_exponent);
 
     // Clone the def, because the current copy will be changed when executing the optimizer

--- a/src/deform_lib/registration/registration_engine.cpp
+++ b/src/deform_lib/registration/registration_engine.cpp
@@ -199,6 +199,7 @@ void RegistrationEngine::build_regularizer(int level, Regularizer& binary_fn)
 {
     binary_fn.set_fixed_spacing(_fixed_pyramids[0].volume(level).spacing());
     binary_fn.set_regularization_weight(_settings.levels[level].regularization_weight);
+    binary_fn.set_regularization_scale(_settings.levels[level].regularization_scale);
     binary_fn.set_regularization_exponent(_settings.levels[level].regularization_exponent);
 
     // Clone the def, because the current copy will be changed when executing the optimizer

--- a/src/deform_lib/registration/settings.cpp
+++ b/src/deform_lib/registration/settings.cpp
@@ -26,6 +26,7 @@ block_size: [12, 12, 12]
 block_energy_epsilon: 0.001
 step_size: 0.5
 regularization_weight: 0.05
+regularization_scale: 1.0
 regularization_exponent: 2.0
 
 levels:
@@ -296,6 +297,10 @@ static void parse_level(const YAML::Node& node, Settings::Level& out) {
         out.regularization_weight = node["regularization_weight"].as<float>();
     }
 
+    if (node["regularization_scale"]) {
+        out.regularization_scale = node["regularization_scale"].as<float>();
+    }
+
     if (node["regularization_exponent"]) {
         out.regularization_exponent = node["regularization_exponent"].as<float>();
     }
@@ -347,6 +352,7 @@ void print_registration_settings(const Settings& settings, std::ostream& s)
         s << "  step_size = " << settings.levels[l].step_size;
         s << "  regularization_weight = " << settings.levels[l].regularization_weight;
         s << "  constraints_weight = " << settings.levels[l].constraints_weight;
+        s << "  regularization_scale = " << settings.levels[l].regularization_scale;
         s << "  regularization_exponent = " << settings.levels[l].regularization_exponent;
         s << "  landmarks_weight = " << settings.levels[l].landmarks_weight;
         s << "  landmarks_decay = " << settings.levels[l].landmarks_decay;

--- a/src/deform_lib/registration/settings.h
+++ b/src/deform_lib/registration/settings.h
@@ -73,6 +73,7 @@ struct Settings
 
         // Only considered if no weight map is given
         float regularization_weight;
+        float regularization_scale;
         float regularization_exponent;
 
         // Step size in [mm]
@@ -93,6 +94,7 @@ struct Settings
             block_energy_epsilon(1e-7f),
             max_iteration_count(-1),
             regularization_weight(0.25f),
+            regularization_scale(1.0f),
             regularization_exponent(2.0f),
             step_size({0.5f, 0.5f, 0.5f}),
             constraints_weight(1000.0f),

--- a/test/test_settings.cpp
+++ b/test/test_settings.cpp
@@ -17,6 +17,7 @@ block_energy_epsilon: 0.00000000009
 max_iteration_count: 100
 step_size: 10.5
 regularization_weight: 0.5
+regularization_scale: 1.1
 regularization_exponent: 1.5
 
 constraints_weight: 1234.1234
@@ -28,6 +29,7 @@ levels:
         max_iteration_count: 99
         step_size: 9.9
         regularization_weight: 9
+        regularization_scale: 0.9
         regularization_exponent: 2.0
 
         constraints_weight: 999.999
@@ -316,6 +318,7 @@ TEST_CASE("parse_registration_file", "")
                 REQUIRE(settings.levels[i].step_size.z == Approx(9.9f));
 
                 REQUIRE(settings.levels[i].regularization_weight == Approx(9.0f));
+                REQUIRE(settings.levels[i].regularization_scale == Approx(0.9f));
                 REQUIRE(settings.levels[i].regularization_exponent == Approx(2.0f));
                 REQUIRE(settings.levels[i].constraints_weight == Approx(999.999f));
             }
@@ -331,6 +334,7 @@ TEST_CASE("parse_registration_file", "")
                 REQUIRE(settings.levels[i].step_size.z == Approx(10.5f));
 
                 REQUIRE(settings.levels[i].regularization_weight == Approx(0.5f));
+                REQUIRE(settings.levels[i].regularization_scale == Approx(1.1f));
                 REQUIRE(settings.levels[i].regularization_exponent == Approx(1.5f));
                 REQUIRE(settings.levels[i].constraints_weight == Approx(1234.1234f));
             }


### PR DESCRIPTION
Yesterday I had an idea, and I tried to vary the exponent for the norm in the regulariser. The idea is that we would like to have stronger penalty where the first derivative is higher, so having a higher exponent would make sense. I still have to look at the theoretical details, though.

The downside is that it weakens the regularisation where the term is lesser than 1, but that can be compensated in part by fiddling with the regularisation weight. It would be possible to also add a scale parameter to move that turning point. It would be interesting to try using a higher exponent only after a certain hard threshold, but that would likely make it harder to prove properties.

I tried running a batch of registrations overnight, and it seems it can give a lot less foldings while at the same time avoiding much of the rigidity and misalignment that comes from just increasing the regularisation weight (above `0.2` things already start to getting visibly misaligned). It is a bit tricky to tune the parameters, and I am not sure how usefult the results will be, but it may worth having a look in this direction.