### PR TITLE
New option: regularize_initial_displacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ To perform a registration
 ```yaml
 pyramid_levels: 6
 pyramid_stop_level: 0
+regularize_initial_displacement: false
 constraints_weight: 1000.0
 landmarks_weight: 1.0
 landmarks_decay: 2.0
@@ -142,6 +143,10 @@ size of the pyramid and at which level to stop the registration. Each level
 halves the resolution of the input volumes. Setting `pyramid_stop_level` to > 0
 specifies that the registration should not be run on the original resolution
 (level 0).
+
+`regularize_initial_displacement` controls whether to include the initial
+displacement in the regularization. This is disabled by default, meaning the
+initial displacement have no effect on the regularization.
 
 `constraints_weight` sets the weight that is applied for constrained voxels. A
 really high value means hard constraints while a lower value may allow

--- a/src/deform_lib/registration/gpu_registration_engine.cpp
+++ b/src/deform_lib/registration/gpu_registration_engine.cpp
@@ -143,8 +143,10 @@ void GpuRegistrationEngine::build_binary_function(int level, GpuBinaryFunction& 
     binary_fn.set_regularization_scale(_settings.levels[level].regularization_scale);
     binary_fn.set_regularization_exponent(_settings.levels[level].regularization_exponent);
 
-    // Clone the def, because the current copy will be changed when executing the optimizer
-    binary_fn.set_initial_displacement(_deformation_pyramid.volume(level).clone());
+    if (!_settings.regularize_initial_displacement) {
+        // Clone the def, because the current copy will be changed when executing the optimizer
+        binary_fn.set_initial_displacement(_deformation_pyramid.volume(level).clone());
+    }
 }
 
 GpuRegistrationEngine::GpuRegistrationEngine(const Settings& settings) :

--- a/src/deform_lib/registration/registration_engine.cpp
+++ b/src/deform_lib/registration/registration_engine.cpp
@@ -203,8 +203,10 @@ void RegistrationEngine::build_regularizer(int level, Regularizer& binary_fn)
     binary_fn.set_regularization_scale(_settings.levels[level].regularization_scale);
     binary_fn.set_regularization_exponent(_settings.levels[level].regularization_exponent);
 
-    // Clone the def, because the current copy will be changed when executing the optimizer
-    binary_fn.set_initial_displacement(_deformation_pyramid.volume(level).clone());
+    if (!_settings.regularize_initial_displacement) {
+        // Clone the def, because the current copy will be changed when executing the optimizer
+        binary_fn.set_initial_displacement(_deformation_pyramid.volume(level).clone());
+    }
 
     #ifdef DF_ENABLE_REGULARIZATION_WEIGHT_MAP
         if (_regularization_weight_map.volume(level).valid())

--- a/src/deform_lib/registration/settings.cpp
+++ b/src/deform_lib/registration/settings.cpp
@@ -21,6 +21,8 @@
 pyramid_levels: 6
 pyramid_stop_level: 0
 
+regularize_initial_displacement: false
+
 constraints_weight: 1000
 
 block_size: [12, 12, 12]
@@ -352,6 +354,7 @@ void print_registration_settings(const Settings& settings, std::ostream& s)
     s << "pyramid_stop_level = " << settings.pyramid_stop_level << std::endl;
     s << "num_pyramid_levels = " << settings.num_pyramid_levels << std::endl;
     s << "landmarks_stop_level = " << settings.landmarks_stop_level << std::endl;
+    s << "regularize_initial_displacement = " << settings.regularize_initial_displacement << std::endl;
 
     for (int l = 0; l < settings.num_pyramid_levels; ++l) {
         s << "level[" << l << "] = {" << std::endl;
@@ -433,6 +436,11 @@ bool parse_registration_settings(const std::string& str, Settings& settings)
 
         if (root["landmarks_stop_level"]) {
             settings.landmarks_stop_level = root["landmarks_stop_level"].as<int>();
+        }
+
+        if (root["regularize_initial_displacement"]) {
+            settings.regularize_initial_displacement
+                = root["regularize_initial_displacement"].as<bool>();
         }
 
         auto is = root["image_slots"];

--- a/src/deform_lib/registration/settings.h
+++ b/src/deform_lib/registration/settings.h
@@ -117,10 +117,14 @@ struct Settings
 
     std::vector<ImageSlot> image_slots;
 
+    // Should the regularization also apply on the initial displacement?
+    bool regularize_initial_displacement;
+
     Settings() :
         pyramid_stop_level(0),
         num_pyramid_levels(6),
-        landmarks_stop_level(0)
+        landmarks_stop_level(0),
+        regularize_initial_displacement(false)
     {
         levels.resize(num_pyramid_levels);
     }

--- a/test/test_settings.cpp
+++ b/test/test_settings.cpp
@@ -22,6 +22,8 @@ regularization_exponent: 1.5
 
 constraints_weight: 1234.1234
 
+regularize_initial_displacement: true
+
 levels:
     3:
         block_size: [9,9,9]
@@ -304,6 +306,7 @@ TEST_CASE("parse_registration_file", "")
 
         REQUIRE(settings.pyramid_stop_level == 2);
         REQUIRE(settings.num_pyramid_levels == 4);
+        REQUIRE(settings.regularize_initial_displacement == true);
 
         for (int i = 0; i < settings.num_pyramid_levels; ++i) {
             if (i == 3) {


### PR DESCRIPTION
Adds a new parameter enabling the user to control whether the initial displacement at each level should be included in the regularization or not.

Fixes #77.